### PR TITLE
Add cfp

### DIFF
--- a/src/Components/Header/index.tsx
+++ b/src/Components/Header/index.tsx
@@ -41,6 +41,16 @@ export default class Header extends React.Component {
                             </a>
                         </li>
                         <li>
+                            <a onClick={this.onNavClick} href="#speakers" data-destination="speakers">
+                                Speakers
+                            </a>
+                        </li>
+                        <li>
+                            <a onClick={this.onNavClick} href="#coc" data-destination="coc">
+                                CoC
+                            </a>
+                        </li>
+                        <li>
                             <a
                                 href=""
                                 target="_blank"

--- a/src/Components/Header/index.tsx
+++ b/src/Components/Header/index.tsx
@@ -41,8 +41,12 @@ export default class Header extends React.Component {
                             </a>
                         </li>
                         <li>
-                            <a onClick={this.onNavClick} href="#speakers" data-destination="speakers">
-                                Speakers
+                            <a
+                                href="https://forms.gle/Hfdba6uCzeUrbmXM9"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                            >
+                                Call for Proposals
                             </a>
                         </li>
                         <li>

--- a/src/Components/Home/Sections/About.tsx
+++ b/src/Components/Home/Sections/About.tsx
@@ -13,11 +13,26 @@ export default class About extends React.Component {
                         We bring the Python Community together for some amazing original Pizza™ and Python Talks.</p>
                     <p>We believe in and encourage practical sessions, in which developers share their experience and lessons from real-world projects, each talk is 10 mins long.</p>
                     <p>Thanks to the Python Pizza (Naples!) that started this format!</p>
+                    <p>Check out the past editions: <a
+                        href="https://python.pizza"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        Naples Python Pizza
+                            </a> and <a
+                            href="https://berlin.python.pizza"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                        >
+                            Berlin Python Pizza
+                            </a> </p>
 
 
                     <br></br>
                     <h1>PyLadies Panel</h1>
-                    <p>On the next day after the conference there will a Coffe, Cake and Panel event organised by the PyLadies Hamburg and Berlin, more info coming soon!</p>
+                    <p>On the next day after the conference there will a Coffee, Cake and Panel event organized by the PyLadies Hamburg and Berlin, more info coming soon!</p>
+
+
 
                 </Container>
             </section>

--- a/src/Components/Home/Sections/About.tsx
+++ b/src/Components/Home/Sections/About.tsx
@@ -7,7 +7,7 @@ export default class About extends React.Component {
         return (
             <section id="about">
                 <Container size={Sizes.medium}>
-                    <h1>Pizza Python</h1>
+                    <h1>Python Pizza</h1>
                     <p><b>Python Pizza</b> is a micro conference organized by the Python Hamburg Community.</p>
                     <p>
                         We bring the Python Community together for some amazing original Pizza™ and Python Talks.</p>

--- a/src/Components/Home/Sections/About.tsx
+++ b/src/Components/Home/Sections/About.tsx
@@ -18,13 +18,13 @@ export default class About extends React.Component {
                         href="https://python.pizza"
                         target="_blank"
                         rel="noopener noreferrer"
-                    ><b>Naples Python Pizza</b>
+                    >Naples Python Pizza
                     </a> and <a
-                        href="https://berlin.python.pizza"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                    >
-                            <b>Berlin Python Pizza</b>
+                            href="https://berlin.python.pizza"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                        >
+                            Berlin Python Pizza
                         </a> </p>
 
 

--- a/src/Components/Home/Sections/About.tsx
+++ b/src/Components/Home/Sections/About.tsx
@@ -13,19 +13,19 @@ export default class About extends React.Component {
                         We bring the Python Community together for some amazing original Pizza™ and Python Talks.</p>
                     <p>We believe in and encourage practical sessions, in which developers share their experience and lessons from real-world projects, each talk is 10 mins long.</p>
                     <p>Thanks to the Python Pizza (Naples!) that started this format!</p>
+                    <br></br>
                     <p>Check out the past editions: <a
                         href="https://python.pizza"
                         target="_blank"
                         rel="noopener noreferrer"
+                    ><b>Naples Python Pizza</b>
+                    </a> and <a
+                        href="https://berlin.python.pizza"
+                        target="_blank"
+                        rel="noopener noreferrer"
                     >
-                        Naples Python Pizza
-                            </a> and <a
-                            href="https://berlin.python.pizza"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                        >
-                            Berlin Python Pizza
-                            </a> </p>
+                            <b>Berlin Python Pizza</b>
+                        </a> </p>
 
 
                     <br></br>

--- a/src/Components/Home/Sections/Coc.css
+++ b/src/Components/Home/Sections/Coc.css
@@ -12,6 +12,11 @@
     h1 {
         text-align: center;
     }
+
+    .container.container--medium p {
+        text-align: left;
+    }
+
     h2 {
         padding-top: 2rem;
         padding-bottom: 1rem;

--- a/src/Components/Home/Sections/Speakers.tsx
+++ b/src/Components/Home/Sections/Speakers.tsx
@@ -22,7 +22,7 @@ export default class Speakers extends React.Component {
                             target="_blank"
                             rel="noopener noreferrer"
                         >
-                            CFP
+                            CfP
                             </a> is open!!! Please apply till 7 September!  Each talk is 10 minutes long and we would love to have many first time speakers!!</p>
                     </Container>
                     <Grid>

--- a/src/Components/Home/Sections/Speakers.tsx
+++ b/src/Components/Home/Sections/Speakers.tsx
@@ -23,7 +23,7 @@ export default class Speakers extends React.Component {
                             rel="noopener noreferrer"
                         >
                             CfP
-                            </a> is open!!! Please apply till 7 September!  Each talk is 10 minutes long and we would love to have many first time speakers!!</p>
+                            </a> is open!!! You have until 7th September to apply!  Each talk will be 10 minutes long and we would love to have many first time speakers!!</p>
                     </Container>
                     <Grid>
                         {this.shuffleArray(SPEAKERS).map((speaker, i) => <SpeakerCard key={i} speaker={speaker} />)}

--- a/src/Components/Home/Sections/Speakers.tsx
+++ b/src/Components/Home/Sections/Speakers.tsx
@@ -17,7 +17,13 @@ export default class Speakers extends React.Component {
                 <Container size={Sizes.large}>
                     <Container size={Sizes.small}>
                         <h1>Speakers</h1>
-                        <p>CFP coming soon</p>
+                        <p>The <a
+                            href="https://forms.gle/Hfdba6uCzeUrbmXM9"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                        >
+                            CFP
+                            </a> is open!!! Please apply till 7 September!  Each talk is 10 minutes long and we would love to have many first time speakers!!</p>
                     </Container>
                     <Grid>
                         {this.shuffleArray(SPEAKERS).map((speaker, i) => <SpeakerCard key={i} speaker={speaker} />)}

--- a/src/Components/Home/index.css
+++ b/src/Components/Home/index.css
@@ -2,7 +2,8 @@
     section {
         padding: 5rem 0;
 
-        .container--small {
+        .container--small,
+        .container--medium {
             h1 {
                 text-align: center;
             }
@@ -12,7 +13,7 @@
             }
             a {
                 color: red;
-              }
+            }
         }
     }
 }

--- a/src/Components/Home/index.css
+++ b/src/Components/Home/index.css
@@ -10,6 +10,9 @@
             p {
                 text-align: center;
             }
+            a {
+                color: red;
+              }
         }
     }
 }

--- a/src/Components/Home/index.tsx
+++ b/src/Components/Home/index.tsx
@@ -16,8 +16,8 @@ export default class Home extends React.Component {
             <div className="home">
                 <Hero />
                 <About />
-                <Sponsors />
                 <Speakers />
+                <Sponsors />
                 <Coc />
             </div>
         );


### PR DESCRIPTION
Call for papers added to Header,
Call for papers mini description added to Speakers tab (link w red)
Speakers tab moved on top of Sponsors
Added Coc to header

Added links to past conferences in Berlin and Napoli to about .. somehow the red from the <a> in the .css didn't want to get applied here so I bolded ( I guess it is overwritten buy some meta parent css thing.. ) 

I am not a big fan of having too many types of style.. should I make the the other link bold and not red.. so that links are either all bold or all red.. (or someone figures out how to make red in about.tsx)